### PR TITLE
Add dynamic stock info tabs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 streamlit
 pandas
 plotly
-requests
-Pillow
+yfinance


### PR DESCRIPTION
## Summary
- overhaul app to include stock question analysis
- split info into summary, price, news, financials, ESG, filings, and portfolio tabs
- add ticker detection and sample data helpers
- update requirements with `yfinance`

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b91557f88832dbfc85528f3c8007e