### PR TITLE
Add cache to price data function

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ def detect_ticker(text: str) -> str | None:
     return None
 
 
+@st.cache_data
 def get_price_data(ticker: str) -> pd.DataFrame | None:
     """Download recent price data using yfinance."""
     try:


### PR DESCRIPTION
## Summary
- cache price data retrieval with `st.cache_data`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c4e53bda0832d8f089821ac5200f9