### PR TITLE
Fix yfinance data download and handle MultiIndex

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,10 @@ def detect_ticker(text: str) -> str | None:
 def get_price_data(ticker: str) -> pd.DataFrame | None:
     """Download recent price data using yfinance."""
     try:
-        data = yf.download(ticker, period="6mo", progress=False)
+        data = yf.download(ticker, period="6mo", progress=False, group_by="column")
+        # Flatten MultiIndex columns that can result from group_by option
+        if isinstance(data.columns, pd.MultiIndex):
+            data = data.droplevel(0, axis=1)
     except Exception:
         return None
     if not data.empty and "Close" in data.columns:


### PR DESCRIPTION
## Summary
- update `get_price_data` to request grouped columns
- flatten MultiIndex columns when downloading price data

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c4e22636c832dbed4593fa5bfa749