### PR TITLE
Use csv for ticker mapping

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,15 +7,17 @@ import yfinance as yf
 
 st.set_page_config(page_title="HyperCLOVA X 기반 AI 투자 어드바이저", layout="wide")
 
-# Mapping of Korean/English company names to ticker symbols
-TICKER_MAP = {
-    "테슬라": "TSLA",
-    "tesla": "TSLA",
-    "애플": "AAPL",
-    "apple": "AAPL",
-    "삼성전자": "005930.KS",
-    "카카오": "035720.KS",
-}
+
+@st.cache_data
+def load_ticker_map() -> dict[str, str]:
+    """Load CSV mapping of company name variants to tickers."""
+    df = pd.read_csv("tickers.csv")
+    # Normalize name column to lowercase for matching
+    return {name.lower(): tkr for name, tkr in zip(df["name"], df["ticker"])}
+
+
+# Mapping of Korean/English company names to ticker symbols loaded from CSV
+TICKER_MAP = load_ticker_map()
 
 
 def detect_ticker(text: str) -> str | None:

--- a/tickers.csv
+++ b/tickers.csv
@@ -1,0 +1,24 @@
+name,ticker
+삼성전자,005930.KS
+Samsung Electronics,005930.KS
+삼성전자우,005935.KS
+테슬라,TSLA
+Tesla,TSLA
+애플,AAPL
+Apple,AAPL
+카카오,035720.KS
+Kakao,035720.KS
+네이버,035420.KS
+Naver,035420.KS
+마이크로소프트,MSFT
+Microsoft,MSFT
+아마존,AMZN
+Amazon,AMZN
+메타,META
+Facebook,META
+현대자동차,005380.KS
+Hyundai Motor,005380.KS
+기아,000270.KS
+Kia,000270.KS
+알파벳,GOOGL
+Google,GOOGL


### PR DESCRIPTION
## Summary
- store company/ticker variants in new `tickers.csv`
- load ticker map from CSV at app startup
- keep `detect_ticker` logic but use the loaded mapping

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import detect_ticker
print(detect_ticker('삼성전자 주가 알려줘'))
PY` *(failed: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_685c50342960832d992080c1221bc082