### PR TITLE
Fix TSLA weight extraction

### DIFF
--- a/tests/test_extract_weight.py
+++ b/tests/test_extract_weight.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import math
+
+from app import extract_ticker_weight
+
+
+def test_extract_numeric():
+    df = pd.DataFrame({"종목": ["TSLA"], "비중(%)": ["25"]})
+    weight = extract_ticker_weight(df, "TSLA")
+    assert weight == 25
+
+
+def test_extract_non_numeric():
+    df = pd.DataFrame({"종목": ["TSLA"], "비중(%)": ["abc"]})
+    weight = extract_ticker_weight(df, "TSLA")
+    assert math.isnan(weight)


### PR DESCRIPTION
## Summary
- extract TSLA weight with `pd.to_numeric` and handle NaN
- notify user when TSLA weight is missing or invalid
- add helper function and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c5802aad4832da9a0899f7c5a797b