### PR TITLE
Add unit tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
+## Running Tests
+
+Execute the test suite with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```
+
 ## Additional Usage Notes
 
 Price charts rely on live market data from Yahoo Finance. Ensure the app has

--- a/tests/test_detect_ticker.py
+++ b/tests/test_detect_ticker.py
@@ -1,0 +1,11 @@
+import pytest
+
+from app import detect_ticker
+
+
+def test_detect_korean_name():
+    assert detect_ticker("테슬라 전망은?") == "TSLA"
+
+
+def test_detect_english_name():
+    assert detect_ticker("Apple outlook") == "AAPL"

--- a/tests/test_get_price_data.py
+++ b/tests/test_get_price_data.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import yfinance as yf
+import pytest
+
+from app import get_price_data
+
+
+def test_get_price_data_flattens_and_returns(monkeypatch):
+    def fake_download(ticker, period="6mo", progress=False, group_by="column"):
+        idx = pd.date_range("2023-01-01", periods=3)
+        cols = pd.MultiIndex.from_product([[ticker], ["Open", "Close"]])
+        return pd.DataFrame([[1, 2], [2, 3], [3, 4]], index=idx, columns=cols)
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    data = get_price_data("AAPL")
+
+    assert not isinstance(data.columns, pd.MultiIndex)
+    assert "Return" in data.columns
+    expected = (3 - 2) / 2
+    assert data["Return"].iloc[1] == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add tests to verify ticker detection
- add tests for price data handling
- include `tests/__init__.py`
- document how to run the test suite in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for streamlit and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c2ba9a8832dbeef426c0008e901