### PR TITLE
Handle empty price download

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,12 @@ def get_price_data(ticker: str, period: str = "6mo") -> pd.DataFrame | None:
     period: str, optional
         Time period for historical data (e.g. "1y", "6mo").
         Included in the cache key so different periods are cached separately.
+
+    Returns
+    -------
+    pd.DataFrame | None
+        The downloaded data with a ``Return`` column, or ``None`` if an error
+        occurs or no data is returned.
     """
     try:
         data = yf.download(ticker, period=period, progress=False, group_by="column")
@@ -65,7 +71,9 @@ def get_price_data(ticker: str, period: str = "6mo") -> pd.DataFrame | None:
             data = data.droplevel(0, axis=1)
     except Exception:
         return None
-    if not data.empty and "Close" in data.columns:
+    if data.empty:
+        return None
+    if "Close" in data.columns:
         data["Return"] = data["Close"].pct_change()
     return data
 
@@ -171,7 +179,7 @@ def extract_ticker_weight(df: pd.DataFrame, ticker: str) -> float | None:
         if ticker:
             # Pass the period explicitly so it becomes part of the cache key
             data = get_price_data(ticker, "6mo")
-            if data is None or data.empty or "Close" not in data.columns:
+            if data is None or "Close" not in data.columns:
                 st.info("주가 데이터를 가져올 수 없습니다. (데이터 없음/컬럼 문제)")
             else:
                 try:

--- a/tests/test_get_price_data.py
+++ b/tests/test_get_price_data.py
@@ -18,3 +18,13 @@ def test_get_price_data_flattens_and_returns(monkeypatch):
     assert "Return" in data.columns
     expected = (3 - 2) / 2
     assert data["Return"].iloc[1] == pytest.approx(expected)
+
+
+def test_get_price_data_returns_none_on_empty(monkeypatch):
+    def fake_download(ticker, period="6mo", progress=False, group_by="column"):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    data = get_price_data("AAPL")
+
+    assert data is None


### PR DESCRIPTION
## Summary
- return None from `get_price_data` when the download is empty
- simplify the check in the price tab
- add a unit test ensuring an empty download returns None

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_685c5f35d2c0832da964b60de1ad5bad