### PR TITLE
Improve error handling for missing CSV

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,17 +1,42 @@
 """Improved AI Investor Advisor app with dynamic stock analysis."""
 
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # Allows tests to run without Streamlit installed
+
+    class _DummyStreamlit:
+        """Minimal stub of Streamlit functions used in tests."""
+
+        @staticmethod
+        def cache_data(func=None, **kwargs):
+            if func is None:
+
+                def decorator(fn):
+                    return fn
+
+                return decorator
+            return func
+
+        @staticmethod
+        def warning(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def info(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def error(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def stop():
+            raise SystemExit
+
+    st = _DummyStreamlit()
 import pandas as pd
 import plotly.express as px
 import yfinance as yf
-
-
-
-def main() -> None:
-    """Run the Streamlit application."""
-    st.set_page_config(
-        page_title="HyperCLOVA X 기반 AI 투자 어드바이저", layout="wide"
-    )
 
 
 def get_recommended_questions() -> list[str]:
@@ -25,10 +50,30 @@ def get_recommended_questions() -> list[str]:
 
 @st.cache_data
 def load_ticker_map() -> dict[str, str]:
-    """Load CSV mapping of company name variants to tickers."""
-    df = pd.read_csv("tickers.csv")
-    # Normalize name column to lowercase for matching
-    return {name.lower(): tkr for name, tkr in zip(df["name"], df["ticker"])}
+    """Load CSV mapping of company name variants to tickers.
+
+    If ``tickers.csv`` cannot be read, show an error and either stop the app or
+    fall back to an example mapping when possible.
+    """
+    example_map = {"테슬라": "TSLA", "애플": "AAPL"}
+    try:
+        df = pd.read_csv("tickers.csv")
+    except FileNotFoundError:
+        st.error("tickers.csv 파일을 찾을 수 없습니다. 기본 매핑으로 실행합니다.")
+        return example_map
+    except Exception as e:
+        st.error(f"tickers.csv를 불러오는 중 오류가 발생했습니다: {e}")
+        st.stop()
+
+    if not {"name", "ticker"}.issubset(df.columns):
+        st.error("tickers.csv에 'name'과 'ticker' 컬럼이 필요합니다.")
+        st.stop()
+
+    try:
+        return {name.lower(): tkr for name, tkr in zip(df["name"], df["ticker"])}
+    except Exception as e:
+        st.error(f"tickers.csv 포맷 오류: {e}")
+        st.stop()
 
 
 # Mapping of Korean/English company names to ticker symbols loaded from CSV
@@ -66,10 +111,12 @@ def get_price_data(ticker: str, period: str = "6mo") -> pd.DataFrame | None:
     """
     try:
         data = yf.download(ticker, period=period, progress=False, group_by="column")
-        # Flatten MultiIndex columns that can result from group_by option
+        # Plotly expects plain string column names. Flatten MultiIndex columns
+        # returned by yfinance and keep only the first level such as "Close".
         if isinstance(data.columns, pd.MultiIndex):
-            data = data.droplevel(0, axis=1)
-    except Exception:
+            data.columns = data.columns.get_level_values(0)
+    except Exception as e:
+        st.warning(f"주가 데이터를 가져오는 중 오류가 발생했습니다: {e}")
         return None
     if data.empty:
         return None
@@ -82,15 +129,29 @@ def get_sample_news(ticker: str) -> list[dict[str, str]]:
     """Provide sample news for the given ticker."""
     sample_news = {
         "TSLA": [
-            {"title": "Tesla launches new model", "summary": "The new EV is expected to expand market share."},
-            {"title": "Analysts positive on Tesla", "summary": "Wall Street sees potential growth in energy business."},
+            {
+                "title": "Tesla launches new model",
+                "summary": "The new EV is expected to expand market share.",
+            },
+            {
+                "title": "Analysts positive on Tesla",
+                "summary": "Wall Street sees potential growth in energy business.",
+            },
         ],
         "AAPL": [
-            {"title": "Apple reveals new iPhone", "summary": "The device includes a faster chip and better camera."},
-            {"title": "Apple services revenue rises", "summary": "Subscription business continues to grow."},
+            {
+                "title": "Apple reveals new iPhone",
+                "summary": "The device includes a faster chip and better camera.",
+            },
+            {
+                "title": "Apple services revenue rises",
+                "summary": "Subscription business continues to grow.",
+            },
         ],
     }
-    return sample_news.get(ticker, [{"title": "관련 뉴스 없음", "summary": "표시할 뉴스가 없습니다."}])
+    return sample_news.get(
+        ticker, [{"title": "관련 뉴스 없음", "summary": "표시할 뉴스가 없습니다."}]
+    )
 
 
 def get_sample_financials(ticker: str) -> dict[str, str]:
@@ -130,20 +191,30 @@ def extract_ticker_weight(df: pd.DataFrame, ticker: str) -> float | None:
     ticker: str
         Ticker symbol to extract weight for.
     """
-    if ticker not in df["종목"].values:
+    try:
+        if ticker not in df["종목"].values:
+            return None
+        weight = pd.to_numeric(
+            df.loc[df["종목"] == ticker, "비중(%)"].iloc[0], errors="coerce"
+        )
+        return weight
+    except KeyError:
+        st.warning("포트폴리오 데이터에 필요한 컬럼이 없습니다.")
         return None
-    weight = pd.to_numeric(
-        df.loc[df["종목"] == ticker, "비중(%)"].iloc[0], errors="coerce"
-    )
-    return weight
 
+
+def main() -> None:
+    """Run the Streamlit application."""
+    st.set_page_config(page_title="HyperCLOVA X 기반 AI 투자 어드바이저", layout="wide")
 
     # Initialize session state
     if "history" not in st.session_state:
         st.session_state.history = []
 
     if "portfolio" not in st.session_state:
-        st.session_state.portfolio = pd.DataFrame({"종목": ["TSLA", "AAPL"], "비중(%)": [60, 40]})
+        st.session_state.portfolio = pd.DataFrame(
+            {"종목": ["TSLA", "AAPL"], "비중(%)": [60, 40]}
+        )
 
     st.title("HyperCLOVA X 기반 AI 투자 어드바이저")
 
@@ -183,14 +254,18 @@ def extract_ticker_weight(df: pd.DataFrame, ticker: str) -> float | None:
                 st.info("주가 데이터를 가져올 수 없습니다. (데이터 없음/컬럼 문제)")
             else:
                 try:
-                    fig_price = px.line(data, y="Close", title=f"{ticker} 최근 6개월 주가")
+                    fig_price = px.line(
+                        data, y="Close", title=f"{ticker} 최근 6개월 주가"
+                    )
                     st.plotly_chart(fig_price, use_container_width=True)
                 except Exception as e:
                     st.warning(f"주가 차트 생성 중 오류가 발생했습니다: {e}")
 
                 if "Return" in data.columns:
                     try:
-                        fig_ret = px.line(data, y="Return", title=f"{ticker} 일간 수익률")
+                        fig_ret = px.line(
+                            data, y="Return", title=f"{ticker} 일간 수익률"
+                        )
                         st.plotly_chart(fig_ret, use_container_width=True)
                     except Exception as e:
                         st.warning(f"수익률 차트 생성 중 오류가 발생했습니다: {e}")
@@ -252,18 +327,21 @@ def extract_ticker_weight(df: pd.DataFrame, ticker: str) -> float | None:
             st.plotly_chart(fig_port, use_container_width=True)
 
             weights = (
-                pd.to_numeric(st.session_state.portfolio["비중(%)"], errors="coerce")
-                .fillna(0)
+                pd.to_numeric(
+                    st.session_state.portfolio["비중(%)"], errors="coerce"
+                ).fillna(0)
                 / 100
             )
-            risk = (weights ** 2).sum() ** 0.5
+            risk = (weights**2).sum() ** 0.5
             st.write(f"단순 위험 지표(예시): {risk:.2f}")
             tsla_weight = extract_ticker_weight(st.session_state.portfolio, "TSLA")
             if tsla_weight is None:
                 st.info("포트폴리오에 테슬라 종목이 없습니다.")
             else:
                 if pd.isna(tsla_weight):
-                    st.warning("테슬라 비중을 숫자로 변환할 수 없습니다. 0으로 처리합니다.")
+                    st.warning(
+                        "테슬라 비중을 숫자로 변환할 수 없습니다. 0으로 처리합니다."
+                    )
                     tsla_weight = 0.0
                 st.write(f"테슬라 비중: {tsla_weight}%")
                 if tsla_weight > 30:
@@ -279,4 +357,3 @@ def extract_ticker_weight(df: pd.DataFrame, ticker: str) -> float | None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- add `error` and `stop` to the Streamlit stub used when tests run without Streamlit installed
- make `load_ticker_map` return an example mapping when `tickers.csv` is missing
- stop the app if the CSV exists but has the wrong format or can't be read
- handle price data download errors more gracefully
- compress the portfolio DataFrame initialization
- format `app.py` with `black`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_685c618c1d5c832d9824f372aba7bb27