### PR TITLE
Fix startup errors for missing ticker data

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,8 +89,8 @@ def get_price_data(ticker: str, period: str = "6mo") -> pd.DataFrame | None:
             group_by="column",
             auto_adjust=False,
         )
-    except TypeError as e:
-        if "auto_adjust" in str(e):
+    except Exception as e:
+        if isinstance(e, TypeError) and "auto_adjust" in str(e):
             try:
                 data = yf.download(
                     ticker,
@@ -102,8 +102,6 @@ def get_price_data(ticker: str, period: str = "6mo") -> pd.DataFrame | None:
                 return None
         else:
             return None
-    except Exception:
-        return None
     # Plotly expects plain string column names. Flatten MultiIndex columns
     # returned by yfinance and keep only the first level such as "Close".
     if isinstance(data.columns, pd.MultiIndex):


### PR DESCRIPTION
## Summary
- prevent `load_ticker_map` from stopping the app when `tickers.csv` is missing or malformed
- call `yf.download` with `auto_adjust=False`, retrying without the argument when unsupported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ca33ce990832d915c02ed4c57d43f